### PR TITLE
Improve convert_hex_to_binary x86_64 codegen.

### DIFF
--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -373,8 +373,8 @@ unsigned constexpr convert_hex_to_binary(const char c) noexcept {
   if (c <= '9') {
     return c - '0';
   }
-  char del = c >= 'a' ? 'a' : 'A';
-  return 10 + (c - del);
+  char del = (c >= 'a' ? 'a' : 'A') - 10;
+  return c - del;
 }
 
 std::string percent_decode(const std::string_view input, size_t first_percent) {


### PR DESCRIPTION
This results in shorter and branchless x86_64 assembly: https://godbolt.org/z/5jqTbYWWh

Original:
```
convert_hex_to_binary(char):             # @convert_hex_to_binary(char)
        mov     eax, edi
        cmp     al, 57
        jg      .LBB0_2
        add     eax, -48
        ret
.LBB0_2:
        xor     ecx, ecx
        cmp     al, 97
        setb    cl
        shl     ecx, 5
        add     eax, ecx
        add     eax, -87
        ret
```
and new version:
```
convert_hex_to_binary(char):             # @convert_hex_to_binary(char)
        xor     ecx, ecx
        cmp     dil, 97
        setl    cl
        shl     ecx, 5
        add     ecx, -87
        cmp     dil, 58
        mov     eax, -48
        cmovge  eax, ecx
        add     eax, edi
        ret
```